### PR TITLE
feat: expand primary color palette for Tailwind

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -7,6 +7,17 @@
 @layer base {
   :root {
     --color-primary: #1E73BE;
+    --color-primary-rgb: 30 115 190;
+    --color-primary-50: #E9F2F9;
+    --color-primary-100: #D3E5F3;
+    --color-primary-200: #A7CBEB;
+    --color-primary-300: #7BB1E3;
+    --color-primary-400: #4F97DA;
+    --color-primary-500: #1E73BE;
+    --color-primary-600: #195F9E;
+    --color-primary-700: #144B7F;
+    --color-primary-800: #0F385F;
+    --color-primary-900: #0A243F;
     --color-secondary: #4DA6FF;
     --color-accent: #FF9900;
     --color-background: #FFFFFF;
@@ -33,5 +44,4 @@ p, span, li, a, blockquote {
   @apply text-2xl;
   /* Macht normalen Text größer */
 }
-
 

--- a/src/pages/blog/[slug].vue
+++ b/src/pages/blog/[slug].vue
@@ -188,12 +188,12 @@ function scrollToFunnel() {
 /* Override the default inverted prose styles for the dark theme */
 .prose-invert {
     --tw-prose-body: theme('colors.secondary');
-    --tw-prose-headings: theme('colors.primary');
+    --tw-prose-headings: theme('colors.primary.500');
     --tw-prose-links: theme('colors.accent');
-    --tw-prose-bold: theme('colors.primary');
+    --tw-prose-bold: theme('colors.primary.500');
     --tw-prose-captions: theme('colors.secondary');
-    --tw-prose-code: theme('colors.primary');
-    --tw-prose-pre-code: theme('colors.primary');
+    --tw-prose-code: theme('colors.primary.500');
+    --tw-prose-pre-code: theme('colors.primary.500');
     --tw-prose-pre-bg: theme('colors.gradient-start');
     --tw-prose-hr: theme('colors.accent-dark');
 }

--- a/src/pages/projekte/[slug].vue
+++ b/src/pages/projekte/[slug].vue
@@ -374,12 +374,12 @@ function scrollToFunnel() {
 <style>
 .prose-invert {
     --tw-prose-body: theme('colors.dark');
-    --tw-prose-headings: theme('colors.primary');
+    --tw-prose-headings: theme('colors.primary.500');
     --tw-prose-links: theme('colors.accent');
-    --tw-prose-bold: theme('colors.primary');
+    --tw-prose-bold: theme('colors.primary.500');
     --tw-prose-captions: theme('colors.dark');
-    --tw-prose-code: theme('colors.primary');
-    --tw-prose-pre-code: theme('colors.primary');
+    --tw-prose-code: theme('colors.primary.500');
+    --tw-prose-pre-code: theme('colors.primary.500');
     --tw-prose-pre-bg: theme('colors.surface');
     --tw-prose-hr: theme('colors.accent');
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,20 @@ export default {
   theme: {
     extend: {
       colors: {
-        primary: 'var(--color-primary)',
+        primary: {
+          DEFAULT: 'rgb(var(--color-primary-rgb) / <alpha-value>)',
+          50: 'var(--color-primary-50)',
+          100: 'var(--color-primary-100)',
+          200: 'var(--color-primary-200)',
+          300: 'var(--color-primary-300)',
+          400: 'var(--color-primary-400)',
+          500: 'var(--color-primary-500)',
+          600: 'var(--color-primary-600)',
+          700: 'var(--color-primary-700)',
+          800: 'var(--color-primary-800)',
+          900: 'var(--color-primary-900)',
+          rgb: 'var(--color-primary-rgb)',
+        },
         secondary: 'var(--color-secondary)',
         accent: 'var(--color-accent)',
         'accent-dark': '#CC7A00',


### PR DESCRIPTION
## Summary
- define CSS variables for primary shades and rgb base
- map Tailwind `colors.primary` to new palette with shades and rgb
- adjust prose components to reference primary.500 token

## Testing
- `npm run build` *(fails: Could not initialize font providers; no `class does not exist` warnings before failure)*

------
https://chatgpt.com/codex/tasks/task_e_68a6129e3b00832b8ab07b9b96976b05