### PR TITLE
Simplify color design and improve button contrast

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -7,17 +7,6 @@
 @layer base {
   :root {
     --color-primary: #1E73BE;
-    --color-primary-rgb: 30 115 190;
-    --color-primary-50: #E9F2F9;
-    --color-primary-100: #D3E5F3;
-    --color-primary-200: #A7CBEB;
-    --color-primary-300: #7BB1E3;
-    --color-primary-400: #4F97DA;
-    --color-primary-500: #1E73BE;
-    --color-primary-600: #195F9E;
-    --color-primary-700: #144B7F;
-    --color-primary-800: #0F385F;
-    --color-primary-900: #0A243F;
     --color-secondary: #4DA6FF;
     --color-accent: #FF9900;
     --color-background: #FFFFFF;

--- a/src/components/home/About.vue
+++ b/src/components/home/About.vue
@@ -39,6 +39,7 @@
     cursor: pointer;
     transition: all 0.3s ease;
     overflow: hidden;
+    color: var(--color-background);
 }
 
 .choice:hover {

--- a/src/components/home/EulahAnimation.vue
+++ b/src/components/home/EulahAnimation.vue
@@ -516,22 +516,23 @@ body {
 .button {
     position: relative;
     padding: 1.5rem;
-    background: transparent;
-    border: 1px solid #ffffff;
+    background: var(--color-primary);
+    border: 1px solid var(--color-primary);
     border-radius: 12px;
     cursor: pointer;
     transition: all 0.3s ease;
     overflow: hidden;
-    color: #ffffff;
+    color: var(--color-background);
     font-size: 1.2rem;
 }
 
 .button:hover {
     transform: scale(1.03);
-    box-shadow: 0 0 15px rgba(0, 212, 255, 0.7),
-        0 0 25px rgba(0, 176, 232, 0.5),
-        inset 0 0 15px rgba(0, 212, 255, 0.3);
-    border-color: #00d4ff;
+    box-shadow: 0 0 15px rgba(77, 166, 255, 0.7),
+        0 0 25px rgba(77, 166, 255, 0.5),
+        inset 0 0 15px rgba(77, 166, 255, 0.3);
+    border-color: var(--color-secondary);
+    background: var(--color-secondary);
 }
 
 /* Mobile Anpassungen */

--- a/src/components/shared/Footer.vue
+++ b/src/components/shared/Footer.vue
@@ -8,8 +8,8 @@
 
       <!-- Links -->
       <div class="flex flex-col sm:flex-row justify-center items-center space-y-3 sm:space-y-0 sm:space-x-6">
-        <a href="/impressum" class="text-sm md:text-base hover:text-accent transition">Impressum</a>
-        <a href="/datenschutz" class="text-sm md:text-base hover:text-accent transition">Datenschutz</a>
+        <a href="/impressum" class="text-sm md:text-base text-accent hover:text-accent-dark transition">Impressum</a>
+        <a href="/datenschutz" class="text-sm md:text-base text-accent hover:text-accent-dark transition">Datenschutz</a>
       </div>
 
       <!-- Footer Note -->

--- a/src/pages/kontakt.vue
+++ b/src/pages/kontakt.vue
@@ -46,7 +46,7 @@
           </div>
 
           <button type="submit"
-            class="w-full py-3 px-6 rounded-full border-2 border-secondary text-background text-xl font-semibold transition-all shadow-lg hover:border-accent hover:bg-primary hover:text-background">
+            class="w-full py-3 px-6 rounded-full bg-primary border-2 border-primary text-background text-xl font-semibold transition-all shadow-lg hover:bg-accent hover:border-accent">
             Nachricht senden
           </button>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,7 @@
 // tailwind.config.js
 /** @type {import('tailwindcss').Config} */
+import colors from 'tailwindcss/colors'
+
 export default {
   content: [
     "./src/components/**/*.{vue,js,ts}", 
@@ -12,30 +14,17 @@ export default {
   theme: {
     extend: {
       colors: {
-        primary: {
-          DEFAULT: 'rgb(var(--color-primary-rgb) / <alpha-value>)',
-          50: 'var(--color-primary-50)',
-          100: 'var(--color-primary-100)',
-          200: 'var(--color-primary-200)',
-          300: 'var(--color-primary-300)',
-          400: 'var(--color-primary-400)',
-          500: 'var(--color-primary-500)',
-          600: 'var(--color-primary-600)',
-          700: 'var(--color-primary-700)',
-          800: 'var(--color-primary-800)',
-          900: 'var(--color-primary-900)',
-          rgb: 'var(--color-primary-rgb)',
-        },
-        secondary: 'var(--color-secondary)',
-        accent: 'var(--color-accent)',
+        primary: colors.blue,
+        secondary: '#4DA6FF',
+        accent: '#FF9900',
         'accent-dark': '#CC7A00',
         'accent-hover': '#E68A00',
         'accent-light': '#FFB84D',
-        background: 'var(--color-background)',
-        surface: 'var(--color-surface)',
-        dark: 'var(--color-dark)',
-        'gradient-start': 'var(--color-surface)',
-        'gradient-end': 'var(--color-background)',
+        background: '#FFFFFF',
+        surface: '#F0F1F2',
+        dark: '#333333',
+        'gradient-start': '#F0F1F2',
+        'gradient-end': '#FFFFFF',
       },
       fontFamily: {
         nunito: ['Nunito', 'sans-serif'],


### PR DESCRIPTION
## Summary
- streamline Tailwind color configuration and remove custom primary shade variables
- fix homepage and contact buttons to use contrasting colors
- show footer Impressum and Datenschutz links in orange by default

## Testing
- `npm run build` *(fails: You have to provide to/cc/bcc in all configs)*

------
https://chatgpt.com/codex/tasks/task_e_68a618186444832bb66cb3c277c5d47e