### PR TITLE
feat: add video hero section

### DIFF
--- a/src/components/home/HeroSection.vue
+++ b/src/components/home/HeroSection.vue
@@ -1,0 +1,48 @@
+<template>
+  <section class="relative h-screen flex items-center overflow-hidden">
+    <video
+      autoplay
+      muted
+      loop
+      playsinline
+      class="absolute inset-0 w-full h-full object-cover"
+    >
+      <source src="/videos/shortify.mp4" type="video/mp4" />
+    </video>
+    <div class="absolute inset-0 bg-black/60" />
+
+    <div class="relative z-10 container mx-auto px-6 md:px-12">
+      <h1 class="text-4xl md:text-6xl font-heading font-bold text-white mb-6">
+        Digitale Lösungen, die begeistern
+      </h1>
+      <p class="text-lg md:text-2xl text-white/90 max-w-2xl mb-8">
+        Wir entwickeln moderne Web- und Softwarelösungen für Unternehmen und Startups.
+      </p>
+      <div class="flex flex-col sm:flex-row gap-4">
+        <NuxtLink
+          to="#services"
+          class="bg-primary hover:bg-primary-600 text-white px-6 py-3 rounded-md text-center"
+        >
+          Unsere Leistungen
+        </NuxtLink>
+        <NuxtLink
+          to="/kontakt"
+          class="bg-transparent border border-white hover:bg-white hover:text-dark px-6 py-3 rounded-md text-center"
+        >
+          Kostenfreies Erstgespräch
+        </NuxtLink>
+      </div>
+
+      <!-- Trustindex component for Google-Bewertungen -->
+      <!-- <HomeTrustIndex class="mt-12" /> -->
+    </div>
+  </section>
+</template>
+
+<script setup>
+// no logic needed
+</script>
+
+<style scoped>
+/* Additional styling can be added here if needed */
+</style>

--- a/src/components/home/TrustIndex.vue
+++ b/src/components/home/TrustIndex.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="ti-widget" id="ti-google-reviews"></div>
+</template>
+
+<script setup>
+import { onMounted } from 'vue'
+
+onMounted(() => {
+  const script = document.createElement('script')
+  script.src = 'https://cdn.trustindex.io/loader.js?xxxxxxxxxxxx' // TODO: Replace with real widget ID
+  script.defer = true
+  document.body.appendChild(script)
+})
+</script>
+
+<style scoped>
+/* Trustindex widget placeholder */
+</style>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,14 +1,14 @@
 <template>
-  <section class="bg-background text-dark min-h-screen relative font-body overflow-hidden">
-    <HomeParticles class="absolute inset-0 z-0 pointer-events-none" />
+  <section class="bg-background text-dark font-body overflow-hidden">
 
     <!-- Hero Section -->
     <ClientOnly>
+      <HomeHeroSection />
       <template #fallback>
-        <!-- This empty container will display until HomeEulahAnimation is loaded -->
+        <!-- This empty container will display until HomeHeroSection is loaded -->
         <div style="height: 100vh;"></div>
       </template>
-      
+
     </ClientOnly>
 
     <!-- Wer wir sind -->
@@ -39,6 +39,8 @@
 
     <!-- Social Proof -->
     <HomeSocialProof />
+    <!-- Google-Bewertungen via Trustindex (aktuell deaktiviert) -->
+    <!-- <HomeTrustIndex /> -->
 
   </section>
 </template>
@@ -60,12 +62,6 @@ useSeoMeta({
 
 
 <style scoped>
-.particles-container,
-.particles-container canvas {
-  pointer-events: none;
-}
-
-
 .card:hover {
   transform: scale(1.05);
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
## Summary
- add hero section with background video and CTA buttons
- scaffold TrustIndex component and comment out until Google profile ready

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: You have to provide to/cc/bcc in all configs.)*

------
https://chatgpt.com/codex/tasks/task_e_68bc519239f0832bb4e3bfd0a1674d80