### PR TITLE
Enhance services section usability

### DIFF
--- a/src/components/home/ServiceCard.vue
+++ b/src/components/home/ServiceCard.vue
@@ -1,10 +1,18 @@
 <template>
-  <NuxtLink :to="link" class="block p-6 bg-gradient-to-br from-background via-surface to-background rounded-2xl shadow-2xl border border-surface hover:border-accent transition-transform duration-300 hover:scale-105">
+  <NuxtLink
+    :to="link"
+    :aria-label="`Mehr über ${title}`"
+    class="flex flex-col h-full p-6 bg-gradient-to-br from-background via-surface to-background rounded-2xl shadow-2xl border border-surface hover:border-accent transition-transform duration-300 hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+  >
     <div class="flex items-center mb-4">
       <i :class="icon" class="text-accent text-3xl mr-4" aria-hidden="true"></i>
       <h3 class="text-xl font-bold text-primary">{{ title }}</h3>
     </div>
-    <p class="text-dark">{{ description }}</p>
+    <p class="text-dark flex-grow">{{ description }}</p>
+    <span class="mt-4 text-accent font-semibold inline-flex items-center">
+      Mehr erfahren
+      <i class="fas fa-arrow-right ml-2" aria-hidden="true"></i>
+    </span>
   </NuxtLink>
 </template>
 

--- a/src/components/home/ServicesSection.vue
+++ b/src/components/home/ServicesSection.vue
@@ -1,8 +1,20 @@
 <template>
-  <section id="services" class="py-24 bg-surface">
+  <section
+    id="services"
+    class="py-24 bg-surface"
+    aria-labelledby="services-heading"
+  >
     <div class="container mx-auto px-6 text-center">
-      <h2 class="text-3xl sm:text-4xl lg:text-5xl font-heading font-bold mb-12">Unsere Leistungen</h2>
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+      <h2
+        id="services-heading"
+        class="text-3xl sm:text-4xl lg:text-5xl font-heading font-bold mb-4"
+      >
+        Unsere Leistungen
+      </h2>
+      <p class="text-lg text-dark mb-12">
+        Was wir für dich tun können – unsere Services im Überblick.
+      </p>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
         <HomeServiceCard
           v-for="service in services"
           :key="service.title"


### PR DESCRIPTION
## Summary
- add intro text and responsive layout to home services section
- improve service cards with accessible link, focus styles and call to action

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint src/components/home/ServicesSection.vue src/components/home/ServiceCard.vue` *(fails: createConfigForNuxt is not defined)*
- `npm run build` *(fails: You have to provide to/cc/bcc in all configs)*

------
https://chatgpt.com/codex/tasks/task_e_68bdafde4658832bbda15c411a73d3bc