### PR TITLE
feat: show service details beside list

### DIFF
--- a/src/components/home/ServicesSection.vue
+++ b/src/components/home/ServicesSection.vue
@@ -13,14 +13,14 @@
         </p>
       </div>
 
-      <!-- Services Grid -->
-      <div class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-8 mb-12">
-        <ServiceCard v-for="service in services" :key="service.id" :service="service" @click="selectService(service)" />
-      </div>
-
-      <!-- Detailed View Modal/Expanded Card -->
-      <div v-if="selectedService" class="mt-16">
-        <ServiceDetail :service="selectedService" @close="selectedService = null" />
+      <!-- Services with inline detail view -->
+      <div class="flex flex-col lg:flex-row gap-8 mb-12">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8 flex-1">
+          <ServiceCard v-for="service in services" :key="service.id" :service="service" @click="selectService(service)" />
+        </div>
+        <div v-if="selectedService" class="flex-1">
+          <ServiceDetail :service="selectedService" @close="selectedService = null" />
+        </div>
       </div>
 
       <!-- Call to Action -->


### PR DESCRIPTION
## Summary
- show service details next to services list on large screens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bdb6f37030832b82132e2957eb8e08