### PR TITLE
fix: remove reload workaround from content pages

### DIFF
--- a/src/pages/blog/[slug].vue
+++ b/src/pages/blog/[slug].vue
@@ -103,26 +103,6 @@ const { data: post, error } = await useAsyncData(route.path, () =>
     queryCollection('blog').path(route.path).first(),
 )
 
-// Clean up when leaving the page
-onBeforeUnmount(() => {
-    if (import.meta.client) {
-        // Remove the reload status for this page
-        sessionStorage.removeItem(`reloaded-${route.path}`)
-    }
-})
-
-// Add onMounted hook to reload page once
-onMounted(() => {
-    // Check if we haven't reloaded yet
-    const hasReloaded = sessionStorage.getItem(`reloaded-${route.path}`)
-
-    if (!hasReloaded && import.meta.client) {
-        // Mark this page as reloaded
-        sessionStorage.setItem(`reloaded-${route.path}`, 'true')
-        // Reload the page
-        window.location.reload()
-    }
-})
 
 
 // Format date to German locale

--- a/src/pages/blog/index.vue
+++ b/src/pages/blog/index.vue
@@ -270,7 +270,6 @@ watch([filteredPosts, itemsPerPage], () => {
 // Clean up when leaving the page
 onBeforeUnmount(() => {
     if (import.meta.client) {
-        sessionStorage.removeItem(`reloaded-${route.path}`)
         window.removeEventListener('resize', updateColumns)
     }
 })
@@ -280,13 +279,6 @@ onMounted(() => {
     updateColumns()
     if (import.meta.client) {
         window.addEventListener('resize', updateColumns)
-    }
-
-    // Optional: keep your original one-time reload logic (left intact)
-    const hasReloaded = sessionStorage.getItem(`reloaded-${route.path}`)
-    if (!hasReloaded && import.meta.client) {
-        sessionStorage.setItem(`reloaded-${route.path}`, 'true')
-        window.location.reload()
     }
 })
 </script>

--- a/src/pages/projekte/[slug].vue
+++ b/src/pages/projekte/[slug].vue
@@ -216,26 +216,7 @@ onMounted(() => {
         videoPlayer.value.addEventListener('play', () => (isPlaying.value = true))
         videoPlayer.value.addEventListener('pause', () => (isPlaying.value = false))
     }
-    // Check if we haven't reloaded yet
-    const hasReloaded = sessionStorage.getItem(`reloaded-${route.path}`)
-
-    if (!hasReloaded && import.meta.client) {
-        // Mark this page as reloaded
-        sessionStorage.setItem(`reloaded-${route.path}`, 'true')
-        // Reload the page
-        window.location.reload()
-    }
 })
-
-
-onBeforeUnmount(() => {
-    if (import.meta.client) {
-        // Remove the reload status for this page
-        sessionStorage.removeItem(`reloaded-${route.path}`)
-    }
-})
-
-
 
 const baseUrl = 'https://www.eulah.de'  // statisch
 

--- a/src/pages/projekte/index.vue
+++ b/src/pages/projekte/index.vue
@@ -105,25 +105,12 @@ onMounted(() => {
   observer = new IntersectionObserver(observerCallback, { rootMargin: "0px", threshold: Array.from({ length: 11 }, (_, i) => i / 10) });
   intersectionRatios.value = projects.value.map(() => 0);
   projectElements.value.forEach((el) => observer.observe(el));
-
-  const hasReloaded = sessionStorage.getItem(`reloaded-${route.path}`)
-
-  if (!hasReloaded && import.meta.client) {
-    // Mark this page as reloaded
-    sessionStorage.setItem(`reloaded-${route.path}`, 'true')
-    // Reload the page
-    window.location.reload()
-  }
 });
 
 onBeforeUnmount(() => {
   window.removeEventListener("resize", handleResize);
   if (observer) observer.disconnect();
 
-  if (import.meta.client) {
-    // Remove the reload status for this page
-    sessionStorage.removeItem(`reloaded-${route.path}`)
-  }
 });
 
 function observerCallback(entries) {


### PR DESCRIPTION
## Summary
- remove sessionStorage-based reload logic from blog and project pages so content renders immediately

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run build` *(fails: You have to provide to/cc/bcc in all configs)*

------
https://chatgpt.com/codex/tasks/task_e_68c5738b793c832bab7e2c3d41b725c8