### PR TITLE
Refresh slug pages on navigation

### DIFF
--- a/src/pages/blog/[slug].vue
+++ b/src/pages/blog/[slug].vue
@@ -98,10 +98,16 @@
 <script setup>
 const route = useRoute()
 
+definePageMeta({
+    key: route => route.fullPath
+})
+
 // Fetch the blog post using the full path with prefix "/blog/"
-const { data: post, error } = await useAsyncData(route.path, () =>
+const { data: post, error, refresh } = await useAsyncData(route.path, () =>
     queryCollection('blog').path(route.path).first(),
 )
+
+watch(() => route.params.slug, () => refresh())
 
 
 

--- a/src/pages/projekte/[slug].vue
+++ b/src/pages/projekte/[slug].vue
@@ -188,11 +188,17 @@
 </template>
 
 <script setup>
-
 const route = useRoute()
-const { data: post } = await useAsyncData(route.path, () =>
+
+definePageMeta({
+    key: route => route.fullPath
+})
+
+const { data: post, refresh } = await useAsyncData(route.path, () =>
     queryCollection('projekte').path(route.path).first()
 )
+
+watch(() => route.params.slug, () => refresh())
 
 const formattedStory = computed(() => {
     if (!post.value?.story) return ''


### PR DESCRIPTION
## Summary
- key blog slug pages by full path and watch slug changes to refresh content
- apply same logic to project slug pages to ensure new data is fetched on navigation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c57d52d550832b96223ad5b1ec0e40