### PR TITLE
Refresh slug pages on navigation

### DIFF
--- a/src/pages/blog/[slug].vue
+++ b/src/pages/blog/[slug].vue
@@ -98,10 +98,18 @@
 <script setup>
 const route = useRoute()
 
-// Fetch the blog post using the full path with prefix "/blog/"
-const { data: post, error } = await useAsyncData(route.path, () =>
-    queryCollection('blog').path(route.path).first(),
+definePageMeta({
+    key: route => route.fullPath
+})
+
+// Fetch the blog post using the current slug and re-fetch when the route changes
+const { data: post, error, refresh } = await useAsyncData(
+    () => queryCollection('blog').path(`/blog/${route.params.slug}`).first(),
+    { watch: [() => route.fullPath] }
 )
+
+// Ensure a fresh fetch when navigating between different slugs
+watch(() => route.params.slug, () => refresh())
 
 
 

--- a/src/pages/blog/index.vue
+++ b/src/pages/blog/index.vue
@@ -172,24 +172,24 @@
 <script setup>
 const route = useRoute()
 
+definePageMeta({
+    key: route => route.fullPath
+})
+
 // Reactive state
 const searchQuery = ref('')
 const currentPage = ref(1)
 const columns = ref(1) // responsive column count (xl:4, lg:3, md:2, sm:1)
 
-const { data: allPosts } = await useAsyncData(route.path, async () => {
-    try {
-        const posts = await queryCollection('blog')
-            .select('path', 'title', 'description', 'date', 'author', 'tags', 'image')
-            .all();
-        return posts || [];
-    } catch (err) {
-        console.error("🔥 Fehler beim Laden der Blog-Posts:", err);
-        throw new Error("Konnte Blog-Posts nicht laden");
+const { data: allPosts } = await useAsyncData(
+    () => queryCollection('blog')
+        .select('path', 'title', 'description', 'date', 'author', 'tags', 'image')
+        .all(),
+    {
+        watch: [() => route.fullPath],
+        default: () => []
     }
-}, {
-    default: () => []
-});
+)
 
 // Computed: filter by search
 const filteredPosts = computed(() => {

--- a/src/pages/projekte/[slug].vue
+++ b/src/pages/projekte/[slug].vue
@@ -188,11 +188,20 @@
 </template>
 
 <script setup>
-
 const route = useRoute()
-const { data: post } = await useAsyncData(route.path, () =>
-    queryCollection('projekte').path(route.path).first()
+
+definePageMeta({
+    key: route => route.fullPath
+})
+
+// Fetch the project using the current slug and update when the route changes
+const { data: post, refresh } = await useAsyncData(
+    () => queryCollection('projekte').path(`/projekte/${route.params.slug}`).first(),
+    { watch: [() => route.fullPath] }
 )
+
+// Force a new fetch when navigating to a different project slug
+watch(() => route.params.slug, () => refresh())
 
 const formattedStory = computed(() => {
     if (!post.value?.story) return ''

--- a/src/pages/projekte/index.vue
+++ b/src/pages/projekte/index.vue
@@ -91,6 +91,10 @@ const intersectionRatios = ref([]);
 const activeProjectId = ref(null);
 const isMobile = ref(false);
 const route = useRoute()
+
+definePageMeta({
+  key: route => route.fullPath
+})
 let observer = null;
 
 


### PR DESCRIPTION
## Summary
- refetch blog posts by slug when navigating and watch route changes
- ensure project detail pages re-query content and refresh on slug change
- key blog and project listings by full path for reliable client-side rendering

## Testing
- `npm run build` *(fails: You have to provide to/cc/bcc in all configs.)*

------
https://chatgpt.com/codex/tasks/task_e_68c57d52d550832b96223ad5b1ec0e40